### PR TITLE
Install postgresql-client-9.6 otherwise export/import doesn't work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,15 @@ FROM debian:jessie
 
 MAINTAINER Pierre-Antoine 'ZHAJOR' Tible <antoinetible@gmail.com>
 
+ENV DEBIAN_FRONTEND=noninteractive
+# Add the PostgreSQL apt repository
+RUN echo '\
+deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' >> /etc/apt/sources.list
+RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+
 RUN apt-get update
-RUN apt-get -y install apache2 libapache2-mod-php5 php5 php5-pgsql wget unzip
+RUN apt-get upgrade
+RUN apt-get -y install apache2 libapache2-mod-php5 php5 php5-pgsql wget unzip postgresql-client-9.6
 RUN apt-get clean
 
 ENV APACHE_RUN_USER www-data


### PR DESCRIPTION
With this pull request, you can 

- import / export from the phppgadmin interface
- use the last version of phppgadmin (which has some fix) since it clones the repository
```
RUN wget https://github.com/phppgadmin/phppgadmin/archive/master.zip
``` 